### PR TITLE
Fix outdated item in Fetchur item list

### DIFF
--- a/Constants.json
+++ b/Constants.json
@@ -62,13 +62,13 @@
     "**Item:** Compass\n**Quantity:** 1|COMPASS",
     "**Item:** Mithril\n**Quantity:** 20|MITHRIL_ORE",
     "**Item:** Firework Rocket\n**Quantity:** 1|FIREWORK",
-    "**Item:** Cheap Coffee or Decent Coffee\n**Quantity:** 1|CHEAP_COFFEE",
+    "**Item:** Cheap Coffee, Decent Coffee or Black Coffee\n**Quantity:** 1|CHEAP_COFFEE",
     "**Item:** Iron Door or Any Wooden Door\n**Quantity:** 1|WOOD_DOOR",
-    "**Item:** Rabbit's Feet\n**Quantity:** 3|RABBIT_FOOT",
+    "**Item:** Rabbit's Foot\n**Quantity:** 3|RABBIT_FOOT",
     "**Item:** Superboom TNT\n**Quantity:** 1|SUPERBOOM_TNT",
     "**Item:** Pumpkin\n**Quantity:** 1|PUMPKIN",
     "**Item:** Flint and Steel\n**Quantity:** 1|FLINT_AND_STEEL",
-    "**Item:** Nether Quartz Ore\n**Quantity:** 50|QUARTZ_ORE",
+    "**Item:** Emerald\n**Quantity:** 50|EMERALD",
     "**Item:** Red Wool\n**Quantity:** 50|WOOL:14"
   ],
   "GUILD_EXP_TO_LEVEL": [


### PR DESCRIPTION
Nether Quartz was [replaced](https://hypixel.net/threads/september-26-skyblock-patch-notes.5500920/) with Emerald in September 2023.

Also made a few other small corrections.